### PR TITLE
Pass in args to InternalMonologue

### DIFF
--- a/Invoke-InternalMonologue.ps1
+++ b/Invoke-InternalMonologue.ps1
@@ -837,6 +837,6 @@ $inmem.ReferencedAssemblies.AddRange($(@("System.dll", $([PSObject].Assembly.Loc
 
 Add-Type -TypeDefinition $Source -Language CSharp -CompilerParameters $inmem 
 
-[InternalMonologue.Program]::Main()
+[InternalMonologue.Program]::Main($args)
 
 }


### PR DESCRIPTION
The powershell version does not pass in the arguments supplied to Invoke-InternalMonologue to the Main() method.

This PR fixes the issue.